### PR TITLE
Coerce `ue_pr` to `CollectorPayload` from `RawEvent` (closes #81)

### DIFF
--- a/core/src/test/resources/recovery_scenarios.json
+++ b/core/src/test/resources/recovery_scenarios.json
@@ -177,21 +177,11 @@
             }
           }
         ],
-        "steps": [
-          {
-            "op": "Replace",
-            "path": "$.raw.parameters.ue_pr.schema",
-            "value": "iglu:com.dataplusmath/video_impression/jsonschema/1-0-0"
-          },
-          {
-            "op": "Add",
-            "path": "$.raw.parameters",
-            "value": [
-              {
-                "name": "schema",
-                "value": "iglu:com.dataplusmath/video_impression/jsonschema/1-0-0"
-              }
-            ]
+        "steps": [{
+          "op": "Replace",
+          "path": "$.raw.parameters.[?(@.name=~ue_pr)].value",
+          "match": "iglu:0/video_impression/jsonschema/1-0-0",
+          "value": "iglu:com.dpm/v_i/jsonschema/1-0-0"
           }
         ]
       }

--- a/core/src/test/scala/com/snowplowanalytics/snowplow/event/recovery/IntegrationSpec.scala
+++ b/core/src/test/scala/com/snowplowanalytics/snowplow/event/recovery/IntegrationSpec.scala
@@ -35,7 +35,7 @@ import org.joda.time.DateTime
 
 class IntegrationSpec extends WordSpec with Inspectors {
   val resolverConfig =
-    """{"schema":"iglu:com.snowplowanalytics.iglu/resolver-config/jsonschema/1-0-1","data":{"cacheSize":0,"repositories":[{"name": "Iglu Central","priority": 0,"vendorPrefixes": [ "com.snowplowanalytics" ],"connection": {"http":{"uri":"http://iglucentral.com"}}},{"name":"Priv","priority":0,"vendorPrefixes":["com.snowplowanalytics"],"connection":{"http":{"uri":"http://iglucentral-dev.com.s3-website-us-east-1.amazonaws.com/release/r114"}}}]}}"""
+    """{"schema":"iglu:com.snowplowanalytics.iglu/resolver-config/jsonschema/1-0-1","data":{"cacheSize":0,"repositories":[{"name": "Iglu Central","priority": 0,"vendorPrefixes": [ "com.snowplowanalytics" ],"connection": {"http":{"uri":"http://iglucentral.com"}}},{"name":"Priv","priority":0,"vendorPrefixes":["com.snowplowanalytics"],"connection":{"http":{"uri":"https://raw.githubusercontent.com/peel/schemas/master"}}}]}}"""
 
   val enrichmentsConfig =
     """{"schema": "iglu:com.snowplowanalytics.snowplow/enrichments/jsonschema/1-0-0", "data": []}"""

--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -33,7 +33,7 @@ import sbtassembly.AssemblyKeys.{assembly, assemblyJarName, assemblyMergeStrateg
 object BuildSettings {
   lazy val commonProjectSettings: Seq[sbt.Setting[_]] = Seq(
     organization := "com.snowplowanalytics",
-    version := "0.3.1",
+    version := "0.3.2-rc2",
     scalaVersion := "2.12.11"
   )
 

--- a/scripts/Recovery.sc
+++ b/scripts/Recovery.sc
@@ -1,7 +1,7 @@
 import ammonite.ops._
 import $ivy.`org.typelevel::cats-core:2.0.0`, cats.Id, cats.instances.list._, cats.syntax.traverse._, cats.syntax.either._
 import $ivy.`io.circe::circe-parser:0.11.1`, io.circe._, io.circe.syntax._, io.circe.parser._
-import $ivy.`com.snowplowanalytics::snowplow-event-recovery-core:0.3.1`, com.snowplowanalytics.snowplow.event.recovery._, config._, json._
+import $ivy.`com.snowplowanalytics::snowplow-event-recovery-core:0.3.2-rc2`, com.snowplowanalytics.snowplow.event.recovery._, config._, json._
 import java.util.concurrent.TimeUnit
 import cats.effect.Clock
 
@@ -27,9 +27,10 @@ object operations {
 // Test full json configuration
 // Useful for quick testing configurations
 object jobs {
-  def test(cfg: String, line: String)               = config.load(cfg).flatMap(execute(_)(line)).flatMap(codecs.thriftDecode).bimap(println, println)
+  def test(cfg: String, line: String)               = config.load(cfg).flatMap(execute(_)(line)).flatMap(codecs.thriftDecode)
   def testMany(cfg: String, lines: List[String])     = lines.toList.map(test(cfg, _))
   def fromFiles(cfgPath: String, linesPath: String) = testMany(load(cfgPath), load(linesPath).split('\n').toList)
+
 }
 
 // Configuration validation

--- a/scripts/test.sc
+++ b/scripts/test.sc
@@ -3,8 +3,9 @@ interp.repositories() ++= Seq(coursierapi.MavenRepository.of("http://maven.snplo
 
 @
 
-import $url.{`https://raw.githubusercontent.com/snowplow-incubator/snowplow-event-recovery/master/scripts/Recovery.sc` => Recovery}, Recovery._
-import $ivy.`com.snowplowanalytics::snowplow-event-recovery-core:0.3.1`, com.snowplowanalytics.snowplow.event.recovery._, config._, json._
+import $file.Recovery, Recovery._
+import $ivy.`com.snowplowanalytics::snowplow-event-recovery-core:0.3.2-rc2`, com.snowplowanalytics.snowplow.event.recovery._, config._, json._
+
 
 // ACTUAL TESTS
 // for available functions see [[https://raw.githubusercontent.com/snowplow-incubator/snowplow-event-recovery/feature/recovery-typeclasses/scripts/Recovery.sc]]


### PR DESCRIPTION
There is a design inconsistency in bad rows that results in an event
that's posted within GET querystring is serialized into `ue_pr` field
in a bad row. In order to recover those situtations into proper
collector payloads it is required to extract the event from that field
and move the nested contents into top-level querystring.

The configuration therefore should not amend the event structure, but
instead modify fields within `ue_pr` field.

Example:
```
"iglu:com.snowplowanalytics.snowplow.badrows/schema_violations/jsonschema/*-*-*": [
      {
        "name": "first",
        "conditions": [
          {
            "op": "Test",
            "path": "$.payload.raw.parameters.ue_pr.data.schema",
            "value": {
              "value": "iglu:0/v_i/jsonschema/1-0-0"
            }
          }
        ],
        "steps": [{
          "op": "Replace",
          "path": "$.raw.parameters.[?(@.name=~ue_pr)].value",
          "match": "iglu:0/video_impression/jsonschema/1-0-0",
          "value": "iglu:com.dpm/v_i/jsonschema/1-0-0"
          }
        ]
      }
```

Will result in following `CollectorPayload`:
```
CollectorPayload(schema:iglu:com.snowplowanalytics.snowplow/CollectorPayload/thrift/1-0-0, ipAddress:00.000.000.000, timestamp:1596239822501, encoding:UTF-8, collector:ssc-1.0.1-kinesis, userAgent:Ro170A), path:/com.snowplowanalytics.iglu/v1, querystring:cb=1&dvc_lat=&ad_len=&height=0&v_id=2008&adv_nm=6&pl_nm=PP&dvc_id=&pl_id=2&u_ip=00.000.000.000&adv_id=4&pub_id=3721&c_nm=17CW&c_id=99&dvc_typ=&v_nm=Tampa&app_id=&ad_id=44&fw_caid=TBVE&app_nm=&ad_nm=71&width=0&u_id=&schema=iglu%3Acom.dpm%2Fv_i%2Fjsonschema%2F1-0-0, hostname:p.tvpixel.com, networkUserId:3e02e9c7-0000-0000-0000-b592ed92120d)
```