### PR TITLE
Bump cats to 2.7.0 (close #112)

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -27,9 +27,9 @@ object Dependencies {
     val jacksonDatabind = "2.10.5.1"
 
     // Scala third-party
-    val atto            = "0.8.0"
-    val catsCore        = "2.6.1"
-    val catsEffect      = "2.5.3"
+    val atto            = "0.9.5"
+    val catsCore        = "2.7.0"
+    val catsEffect      = "2.5.4"
     val circe           = "0.14.1"
     val circeOptics     = "0.14.1"
     val monocle         = "2.1.0"
@@ -38,8 +38,8 @@ object Dependencies {
     val flink           = "1.10.0"
     val scio            = "0.11.5"
     val beam            = "2.36.0"
-    val decline         = "0.5.0"
-    val declineEffect   = "1.0.0"
+    val decline         = "1.4.0"
+    val declineEffect   = "1.4.0"
     val scalaMacros     = "2.1.0"
 
     // Scala first-party

--- a/shell.nix
+++ b/shell.nix
@@ -8,8 +8,8 @@
 # in
 let
   spkgs = rec {
-    jdk = pkgs.openjdk.override{enableJavaFX = false;};
-    jre = pkgs.openjdk17_headless;
+    jdk = pkgs.openjdk11;
+    jre = pkgs.openjdk11;
     scala = pkgs.scala.override{inherit jre;};
     sbt = pkgs.sbt.override{inherit jre;};
     coursier = pkgs.coursier.override{inherit jre;};
@@ -20,6 +20,7 @@ in pkgs.mkShell {
     metals
     sbt
     pkgs.entr
+    pkgs.awscli
   ];
   shellHook = ''
   '';

--- a/spark/src/main/scala/com/snowplowanalytics/snowplow/event/recovery/Main.scala
+++ b/spark/src/main/scala/com/snowplowanalytics/snowplow/event/recovery/Main.scala
@@ -17,7 +17,6 @@ package com.snowplowanalytics.snowplow.event.recovery
 import scala.concurrent.duration.{MILLISECONDS, NANOSECONDS, TimeUnit}
 import com.amazonaws.regions.Regions
 
-import cats.Id
 import cats.implicits._
 import cats.effect._
 
@@ -28,6 +27,7 @@ import jp.co.bizreach.kinesis.recordsMaxDataSize
 import util.paths._
 import util.base64
 import config._
+import cats.data.EitherT
 
 /** Entry point for the Spark recovery job */
 object Main
@@ -87,7 +87,9 @@ object Main
       )
       .mapValidated(base64.decode(_).leftMap(_.message).toValidatedNel)
 
-    val validatedConfig = (resolver, config).mapN((r, c) => validateSchema[Id](c, r).map(_ => c).value.flatMap(load(_)))
+    val validatedConfig = (resolver, config).mapN((r, c) =>
+      validateSchema[IO](c, r).map(_ => c).flatMap(v => EitherT.fromEither(load(v))).value
+    )
 
     (
       input,
@@ -99,28 +101,23 @@ object Main
       batchSize,
       validatedConfig
     ).mapN { (i, o, f, u, d, r, b, c) =>
-      IO.fromEither(
-        c.map(
-          RecoveryJob.run(
-            i,
-            o,
-            f.getOrElse(failedPath(i)),
-            u.orElse(f.map(unrecoverablePath)).getOrElse(unrecoverablePath(i)),
-            d,
-            Either.catchNonFatal(Regions.fromName(r)).getOrElse(Regions.EU_CENTRAL_1),
-            b.getOrElse(recordsMaxDataSize),
-            _
-          )
-        ).map(_ => ExitCode.Success)
-          .leftMap(new RuntimeException(_))
-      )
-    }
-  }
+      c.map(
+        _.bimap(
+          err => new RuntimeException(err),
+          cfg =>
+            RecoveryJob.run(
+              i,
+              o,
+              f.getOrElse(failedPath(i)),
+              u.orElse(f.map(unrecoverablePath)).getOrElse(unrecoverablePath(i)),
+              d,
+              Either.catchNonFatal(Regions.fromName(r)).getOrElse(Regions.EU_CENTRAL_1),
+              b.getOrElse(recordsMaxDataSize),
+              cfg
+            )
+        )
+      ).map(_ => ExitCode.Success)
 
-  implicit val catsClockIdInstance: Clock[Id] = new Clock[Id] {
-    override def realTime(unit: TimeUnit): Id[Long] =
-      unit.convert(System.nanoTime(), NANOSECONDS)
-    override def monotonic(unit: TimeUnit): Id[Long] =
-      unit.convert(System.currentTimeMillis(), MILLISECONDS)
+    }
   }
 }


### PR DESCRIPTION
Update cats to 2.7.0 along with its requirements. Includes additional shading strategy to make Spark 3.1.2 work (given it's running JRE11)