### PR TITLE
Handle url-unsafe Base64 encodings (close #137)

### DIFF
--- a/core/src/main/scala/com/snowplowanalytics/snowplow/event/recovery/utils/base64.scala
+++ b/core/src/main/scala/com/snowplowanalytics/snowplow/event/recovery/utils/base64.scala
@@ -33,9 +33,9 @@ object base64 {
 
   def decode[A](encoded: String, fn: Array[Byte] => A = byteToString): Recovering[A] =
     Either
-      .catchNonFatal(Base64.getDecoder.decode(encoded))
+      .catchNonFatal(Base64.getDecoder.decode(encoded.replaceAll("-","+").replaceAll("_","/").getBytes("UTF-8")))
       .map(fn)
-      .leftMap(e => Base64Failure(encoded, s"Configuration is not properly base64-encoded: ${e.getMessage}"))
+      .leftMap(e => Base64Failure(encoded, s"Data is not properly base64-encoded: ${e.getMessage}"))
 
   /** Decode a base64-encoded string.
     * @param encoded

--- a/core/src/test/scala/com/snowplowanalytics/snowplow/event/recovery/util/Base64Spec.scala
+++ b/core/src/test/scala/com/snowplowanalytics/snowplow/event/recovery/util/Base64Spec.scala
@@ -29,7 +29,12 @@ class Base64Spec extends AnyWordSpec with ScalaCheckPropertyChecks with EitherVa
       base64.decode("YWJjCg==") shouldEqual Right("abc\n")
     }
     "send an error message if not base64" in {
-      base64.decode("é").left.value.message should include("Configuration is not properly base64-encoded")
+      base64.decode("é").left.value.message should include("Data is not properly base64-encoded")
+    }
+    "successfilly decode url-unsafe alphabet base64 string" in {
+      val expected = """What does 2 + 2.1 equal?? ~ 4"""
+      base64.decode("V2hhdCBkb2VzIDIgKyAyLjEgZXF1YWw/PyB+IDQ=") shouldEqual Right(expected)
+      base64.decode("V2hhdCBkb2VzIDIgKyAyLjEgZXF1YWw_PyB-IDQ")  shouldEqual Right(expected)
     }
   }
 


### PR DESCRIPTION
Some trackers base64-encode strings using url-unsafe methods. These strings contain special 62nd and 63rd characters in alphabet: `-` and `_`. This would previously lead to recovery failures as the string wasn't properly decoded. And the error was attributed to the configuration issue.

In order to keep backwards-compatibility with the tracker behavior we need to work around it by replacing the 62nd and 63rd characters with corresponding characters from with URL and filename safe alphabet[1]: `+` and `/`.

1 - http://tools.ietf.org/html/rfc4648#page-7