### PR TITLE
Use Double for casting number types

### DIFF
--- a/core/src/main/scala/com/snowplowanalytics/snowplow/event/recovery/inspect/cast.scala
+++ b/core/src/main/scala/com/snowplowanalytics/snowplow/event/recovery/inspect/cast.scala
@@ -55,7 +55,7 @@ object cast {
     case (CastType.String, CastType.Numeric) if value.isString =>
       value
         .asString
-        .flatMap(v => Either.catchNonFatal(v.toLong.asJson).toOption)
+        .flatMap(v => Either.catchNonFatal(v.toDouble.asJson).toOption)
         .toRight(CastFailure(value.noSpaces, from, to))
     case _ => Left(CastFailure(value.noSpaces, from, to))
   }


### PR DESCRIPTION
Previously we used `Long` as a number type when casting. This would cause failures when operating on non-Natural numbers. Now, the numbers are converted to `Double`.
This is similar to `Add` operation when adding numbers.

