### PR TITLE
Do not decode iglu json webhook ue_pr paramter on coerce

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+Version 0.7.2 (2024-06-26)
+--------------------------
+Do not decode iglu json webhook ue_pr paramter on coerce (close #144)
+
 Version 0.7.1 (2024-06-18)
 --------------------------
 Make NVP codec isomorphic (close #143)

--- a/core/src/test/resources/expected_payloads.json
+++ b/core/src/test/resources/expected_payloads.json
@@ -224,24 +224,19 @@
     "event_version": "2-0-0"
   },
   {
-    "platform": "app",
-    "etl_tstamp": "1970-01-18T08:40:00",
-    "collector_tstamp": "2024-02-02T12:51:38.534",
-    "event": "unstruct",
-    "v_tracker": "com.snowplowanalytics.iglu-v1",
-    "v_collector": "ssc-2.10.0-kinesis",
-    "user_ipaddress": "34.76.244.217",
-    "network_userid": "ccbd375d-e37f-4919-811c-780f460a3ed4",
-    "page_url": "https://www.lorem.com/Ipsum-dolor-sit-AMET",
-    "page_urlscheme": "https",
-    "page_urlhost": "www.lorem.com",
-    "page_urlport": 443,
-    "page_urlpath": "/Ipsum-dolor-sit-AMET",
-    "useragent": "python-requests/2.31.0",
-    "derived_tstamp": "2024-02-02T12:51:38.534",
-    "event_vendor": "com.snowplowanalytics.iglu",
-    "event_name": "anything-a",
-    "event_format": "jsonschema",
-    "event_version": "1-0-0"
-  }
+    "platform" : "app",
+    "etl_tstamp" : "1970-01-18T08:40:00",
+    "collector_tstamp" : "2024-02-02T12:51:38.534",
+    "event" : "unstruct",
+    "v_tracker" : "com.snowplowanalytics.iglu-v1",
+    "v_collector" : "ssc-2.10.0-kinesis",
+    "user_ipaddress" : "34.76.244.217",
+    "network_userid" : "ccbd375d-e37f-4919-811c-780f460a3ed4",
+    "useragent" : "python-requests/2.31.0",
+    "derived_tstamp" : "2024-02-02T12:51:38.534",
+    "event_vendor" : "com.snowplowanalytics.iglu",
+    "event_name" : "anything-a",
+    "event_format" : "jsonschema",
+    "event_version" : "1-0-0"
+   }
 ]


### PR DESCRIPTION
When attempting convering RawEvent into CollectorPayload we previously
were convering it through proper JSON decoder. But as this is already
manually modified through recovery process we can skip decoding and
instead simply pass the JSON.
Otherwise we'd need to alter RawEvent to contain `body` field which it
is missing. And we cannot.

-------

<!--
Thank you for contributing to Snowplow Event Recovery!

You'll find a small checklist below which should help speed up the
review processs:

- [ ] Have you signed the [contributor license agreement](https://github.com/snowplow/snowplow/wiki/CLA)?
- [ ] Have you read the [contributing guide](https://github.com/snowplow-incubator/snowplow-event-recovery/blob/master/CONTRIBUTING.md)?
- [ ] Have you added the appropriate unit tests?
- [ ] Have you run the tests through `sbt test`?
- [ ] Is your pull request against the `develop` branch?
-->